### PR TITLE
Add additional features

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Create a new bug report
+title: "[BUG]"
+labels: ''
+assignees: ''
+
+---
+
+**Description/Screenshot**
+
+**Steps to Reproduce**
+
+ - Grunt Version
+ - NPM Version
+ - TypeScript Version
+
+**Expected behavior**
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.2.0
+
+## Changelog
+
+- Add additional features
+  - Support for ```src``` and ```out``` properties on the task to assist with migrating from [grunt-ts](https://www.npmjs.com/package/grunt-ts). Note: Not all of the grunt-ts features are supported and the generation approach is slightly different.
+  - Add an ```onError``` task callback to allow project driven pass / fail based on specific TypeScript errors.
+  
 # v0.1.0
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Note: These plugins have currently only been tested with the Grunt `1.4.0`.
 
 # Quickstart
 
-## grunt-ts-plugin
+## [grunt-ts-plugin](./ts-plugin/README.md)
 
 `npm install @nevware21/grunt-ts-plugin --save-dev`
 
@@ -32,7 +32,29 @@ module.exports = function(grunt) {
   grunt.initConfig({
     ts: {
       default : {
-        tsconfig: './tsconfig.json'
+        debug: false
+      },
+      task1: {
+        // Just use the tsconfig
+        tsconfig: './task1/tsconfig.json'
+      },
+      task2: {
+        // Use the tsconfig and add the additional src files, you *could* call a function to return
+        // a dynamic array with the src files. The task doesn't call the function it expects a string[].
+        tsconfig: './task1/tsconfig.json',
+        src: [
+          './src/**/*.ts'
+        ]
+      },
+      task3: {
+        // As with task2, but also concatenate the output into a single file, this is the same as defining
+        // the out or outFile paramater in the compileOptions within the tsconfig.json.
+        // If you have both outDir in the tsConfig.json and this parameter -- this value will be ignored.
+        tsconfig: './task1/tsconfig.json',
+        src: [
+          './src/**/*.ts'
+        ],
+        out: './out/task1-dist.js'
       }
     }
   });

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -58,9 +58,9 @@
       "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/@azure/core-http": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.5.tgz",
-      "integrity": "sha512-SjjjqaO9emyn+XM0Qyzt5RsgddOIpGAfhWH6+d8X6/HbhFrtvXLJIz85EMoIO+T4rX3ISStik9MD5LMW9IZg4A==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.6.tgz",
+      "integrity": "sha512-odtH7UMKtekc5YQ86xg9GlVHNXR6pq2JgJ5FBo7/jbOjNGdBqcrIVrZx2bevXVJz/uUTSx6vUf62gzTXTfqYSQ==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-asynciterator-polyfill": "^1.0.0",
@@ -73,7 +73,7 @@
         "node-fetch": "^2.6.0",
         "process": "^0.11.10",
         "tough-cookie": "^4.0.0",
-        "tslib": "^2.0.0",
+        "tslib": "^2.2.0",
         "tunnel": "^0.0.6",
         "uuid": "^8.3.0",
         "xml2js": "^0.4.19"
@@ -714,7 +714,7 @@
     "node_modules/@rush-temp/grunt-ts-plugin": {
       "version": "0.0.0",
       "resolved": "file:projects/grunt-ts-plugin.tgz",
-      "integrity": "sha512-DO+NulZj1taOjTqZr4DSHn5E9OWSyYFSv8RnnEPq1DcVlZL3aFzzuu5beKCGl0u16vAv0eCMoYTyxVt1bgltQw==",
+      "integrity": "sha512-Q+Qfi81hgAe9+KoFCsEn4XzU6HV1xzWqcdcszgLelWNSo/jLSOLnxR3b8VBEw/+AQ0C0ZCOy+BKEjetUBEzBVA==",
       "dependencies": {
         "@rollup/plugin-commonjs": "^19.0.0",
         "@rollup/plugin-node-resolve": "^13.0.0",
@@ -3209,9 +3209,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.51.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.51.2.tgz",
-      "integrity": "sha512-ReV2eGEadA7hmXSzjxdDKs10neqH2QURf2RxJ6ayAlq93ugy6qIvXMmbc5cWMGCDh1h5T4thuWO1e2VNbMq8FA==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.0.tgz",
+      "integrity": "sha512-lSkBDGsVoXjqaBf7dsHwxBJz+p+hJEP72P+LOitA0yVs+Nzxj76FidkZE2thrmhjwGqLYiJo39opi7mAfaQ/Vg==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -3219,7 +3219,7 @@
         "node": ">=10.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/rollup/node_modules/fsevents": {
@@ -3664,16 +3664,16 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.20.36",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.36.tgz",
-      "integrity": "sha512-qFU+DWMV/hifQ9ZAlTjdFO9wbUIHuUBpNXzv68ZyURAP9pInjZiO4+jCPeAzHVcaBCHER9WL/+YzzTt6ZlN/Nw==",
+      "version": "0.20.37",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.37.tgz",
+      "integrity": "sha512-9+qDhdc4X00qTNOtii6QX2z7ndAeWVOso7w3MPSoSJdXlVhpwPfm1yEp4ooKuWA9fiQILR8FKkyjmeqa13hBbw==",
       "dependencies": {
         "colors": "^1.4.0",
         "fs-extra": "^9.1.0",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "lunr": "^2.3.9",
-        "marked": "^2.0.3",
+        "marked": "~2.0.3",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.4",
@@ -3989,9 +3989,9 @@
       }
     },
     "@azure/core-http": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.5.tgz",
-      "integrity": "sha512-SjjjqaO9emyn+XM0Qyzt5RsgddOIpGAfhWH6+d8X6/HbhFrtvXLJIz85EMoIO+T4rX3ISStik9MD5LMW9IZg4A==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.6.tgz",
+      "integrity": "sha512-odtH7UMKtekc5YQ86xg9GlVHNXR6pq2JgJ5FBo7/jbOjNGdBqcrIVrZx2bevXVJz/uUTSx6vUf62gzTXTfqYSQ==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-asynciterator-polyfill": "^1.0.0",
@@ -4004,7 +4004,7 @@
         "node-fetch": "^2.6.0",
         "process": "^0.11.10",
         "tough-cookie": "^4.0.0",
-        "tslib": "^2.0.0",
+        "tslib": "^2.2.0",
         "tunnel": "^0.0.6",
         "uuid": "^8.3.0",
         "xml2js": "^0.4.19"
@@ -4501,7 +4501,7 @@
     },
     "@rush-temp/grunt-ts-plugin": {
       "version": "file:projects\\grunt-ts-plugin.tgz",
-      "integrity": "sha512-DO+NulZj1taOjTqZr4DSHn5E9OWSyYFSv8RnnEPq1DcVlZL3aFzzuu5beKCGl0u16vAv0eCMoYTyxVt1bgltQw==",
+      "integrity": "sha512-Q+Qfi81hgAe9+KoFCsEn4XzU6HV1xzWqcdcszgLelWNSo/jLSOLnxR3b8VBEw/+AQ0C0ZCOy+BKEjetUBEzBVA==",
       "requires": {
         "@rollup/plugin-commonjs": "^19.0.0",
         "@rollup/plugin-node-resolve": "^13.0.0",
@@ -6440,11 +6440,11 @@
       }
     },
     "rollup": {
-      "version": "2.51.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.51.2.tgz",
-      "integrity": "sha512-ReV2eGEadA7hmXSzjxdDKs10neqH2QURf2RxJ6ayAlq93ugy6qIvXMmbc5cWMGCDh1h5T4thuWO1e2VNbMq8FA==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.0.tgz",
+      "integrity": "sha512-lSkBDGsVoXjqaBf7dsHwxBJz+p+hJEP72P+LOitA0yVs+Nzxj76FidkZE2thrmhjwGqLYiJo39opi7mAfaQ/Vg==",
       "requires": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       },
       "dependencies": {
         "fsevents": {
@@ -6772,16 +6772,16 @@
       }
     },
     "typedoc": {
-      "version": "0.20.36",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.36.tgz",
-      "integrity": "sha512-qFU+DWMV/hifQ9ZAlTjdFO9wbUIHuUBpNXzv68ZyURAP9pInjZiO4+jCPeAzHVcaBCHER9WL/+YzzTt6ZlN/Nw==",
+      "version": "0.20.37",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.37.tgz",
+      "integrity": "sha512-9+qDhdc4X00qTNOtii6QX2z7ndAeWVOso7w3MPSoSJdXlVhpwPfm1yEp4ooKuWA9fiQILR8FKkyjmeqa13hBbw==",
       "requires": {
         "colors": "^1.4.0",
         "fs-extra": "^9.1.0",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "lunr": "^2.3.9",
-        "marked": "^2.0.3",
+        "marked": "~2.0.3",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.4",

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -55,6 +55,7 @@ module.exports = function (grunt) {
         ts: {
             options: {
                 debug: true,
+                logOutput: false,
                 comments: true
             },
             "shared_utils": {
@@ -65,9 +66,9 @@ module.exports = function (grunt) {
             },
             "ts_plugin": {
                 tsconfig: "./ts-plugin/tsconfig.json",
-                src: [
-                    './ts-plugin/src/**/*.ts'
-                ],
+                // src: [
+                //     './ts-plugin/src/**/*.ts'
+                // ],
                 //out: "ts-plugin/tasks/ts.js"
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "grunt-plugins",
     "description": "Plugin for GruntJS",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "homepage": "https://github.com/nevware21/grunt-plugins",
     "keywords": [
         "grunt",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@nevware21/grunt-plugins-shared-utils",
     "description": "Shared Utils GruntJS Plugins",
-    "version": "0.0.1",
+    "version": "0.2.0",
     "homepage": "https://github.com/nevware21/grunt-plugins",
     "keywords": [
         "grunt",

--- a/shared/src/shared-utils.ts
+++ b/shared/src/shared-utils.ts
@@ -11,4 +11,7 @@ export { IExecuteResponse } from "./interfaces/IExecuteResponse";
 
 export { doExecute } from "./execute";
 export { getRandomHex } from "./random";
-export { isUndefined, getTempFile, getGruntMultiTaskOptions, resolveValue, quoteIfRequired, findCommonRoot, findCommonPath } from "./utils";
+export {
+    isUndefined, isPromiseLike, isPromise, 
+    getTempFile, getGruntMultiTaskOptions, resolveValue, quoteIfRequired, findCommonRoot, findCommonPath, normalizePath
+} from "./utils";

--- a/shared/src/utils.ts
+++ b/shared/src/utils.ts
@@ -15,6 +15,14 @@ export function isUndefined(value: any) {
     return value === undefined || typeof value === 'undefined';
 }
 
+export function isPromiseLike<T>(value: any): value is PromiseLike<T> {
+    return value && typeof value.then === "function";
+}
+
+export function isPromise<T>(value: any): value is Promise<T> {
+    return isPromiseLike(value) && typeof (value as any).catch === "function";
+}
+
 /**
  * Get a unique temporary file
  *
@@ -91,7 +99,7 @@ export function findCommonRoot(values: string[]) {
     }
 
     let sorted = values.slice(0).sort();
-    let firstValue = sorted[0];
+    let firstValue = sorted[0] as string;
     let lastValue = sorted[sorted.length - 1];
     let len = firstValue.length;
     let idx = 0;
@@ -103,7 +111,7 @@ export function findCommonRoot(values: string[]) {
 }
 
 export function findCommonPath(paths: string[], seperator?: string) {
-    let commonPath = findCommonRoot(paths);
+    let commonPath = findCommonRoot(paths.map((value) => normalizePath(value)));
     let endIdx = -1;
 
     if (commonPath) {
@@ -119,4 +127,12 @@ export function findCommonPath(paths: string[], seperator?: string) {
     }
 
     return commonPath.substring(0, endIdx);
+}
+
+export function normalizePath(path: string) {
+    if (path) {
+        return path.replace(/\\/g, "/");
+    }
+
+    return path || "";
 }

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -17,9 +17,6 @@
       "allowSyntheticDefaultImports": true,
       "rootDir": "./src"
     },
-    "include": [
-      "./src/**/*.ts"
-    ],
     "exclude": [
         "node_modules/"
       ]

--- a/ts-plugin/package.json
+++ b/ts-plugin/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@nevware21/grunt-ts-plugin",
     "description": "TypeScript Compilation Plugin for GruntJS",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "homepage": "https://github.com/nevware21/grunt-plugins",
     "author": {
         "name": "Nevware21",
@@ -11,11 +11,13 @@
         "grunt",
         "gruntplugin",
         "typescript",
-        "task"
+        "task",
+        "compiler",
+        "build"
     ],
     "scripts": {
         "clean": "grunt clean",
-        "build": "grunt ts_plugin && npm run package",
+        "build": "grunt ts_plugin --verbose && npm run package",
         "rebuild": "npm run build",
         "package": "rollup -c rollup.config.js",
         "test": "grunt ts_plugin_test",
@@ -31,7 +33,7 @@
     "licenses": [
         {
             "type": "MIT",
-            "url": "https://github.com/nevware21/grunt-plugins/blob/master/LICENSE-MIT"
+            "url": "https://github.com/nevware21/grunt-plugins/blob/master/LICENSE"
         }
     ],
     "engines": {
@@ -41,7 +43,7 @@
     },
     "devDependencies": {
         "@types/grunt": "0.4.25",
-        "@nevware21/grunt-plugins-shared-utils": "0.0.1",
+        "@nevware21/grunt-plugins-shared-utils": "0.2.0",
         "grunt": "^1.4.0",
         "grunt-cli": "^1.4.3",
         "typescript": "^4.2.0",

--- a/ts-plugin/src/interfaces/ICompileResponse.ts
+++ b/ts-plugin/src/interfaces/ICompileResponse.ts
@@ -9,4 +9,5 @@
 export interface ICompileResponse {
     time: number;
     isSuccess: boolean;
+    errors: string[];
 }

--- a/ts-plugin/src/interfaces/IErrorHandler.ts
+++ b/ts-plugin/src/interfaces/IErrorHandler.ts
@@ -1,0 +1,34 @@
+/*
+ * @nevware21/grunt-ts-plugins
+ * https://github.com/nevware21/grunt-plugins
+ *
+ * Copyright (c) 2021 Nevware21
+ * Licensed under the MIT license.
+ */
+
+export enum ErrorHandlerResponse {
+    /**
+     * The handler did not identify whether this should be treated as an error, warning or ignore. 
+     * So follow normal built in handling.
+     * Null and undefined responses are treated the same as this value
+     */
+    Undefined = 0,
+
+    /**
+     * Ignore this error with no logging
+     */
+    Ignore = 1,
+
+    /**
+     * Include the error in the log, but don't treat as an error or warning
+     */
+    Silent = 2,
+
+     /**
+     * Treat as an error and fail the build
+     */
+    Error = 3,
+}
+
+export type OnErrorHandler = (errorNumber: string, line?: string) => ErrorHandlerResponse;
+

--- a/ts-plugin/src/interfaces/ITsPluginOptions.ts
+++ b/ts-plugin/src/interfaces/ITsPluginOptions.ts
@@ -6,20 +6,27 @@
  * Licensed under the MIT license.
  */
 
-export interface ITsPluginOptions {
+import { OnErrorHandler } from "./IErrorHandler";
+
+export interface ITsCommonOptions {
     /**
      * Log additional debug messages as verbose grunt messages
      */
     debug?: boolean;
 
-    /**
+     /**
+     * Log the output of the execute response
+     */
+    logOutput?: boolean;
+ 
+     /**
      * Pass in additional flags to the tsc compiler (added to the end of the command line)
      */
     additionalFlags?: string | string[];
 
     /**
-     * Should the compile run fail when type errors are identified
-     */
+    * Should the compile run fail when type errors are identified
+    */
     failOnTypeErrors?: boolean;
  
     /**
@@ -37,52 +44,31 @@ export interface ITsPluginOptions {
     compiler?: string;
 
     /**
-     * If specified, outDir files are located relative to this location
+     * This callback function will be called when an error matching "error: TS\d+:" is found, the errorNumber is the
+     * detected value and line is the entire line containing the error message.
+     * @returns ErrorHandlerResponse value
      */
-    baseDir?: string;
+     onError?: OnErrorHandler;
+ }
+
+export interface ITsPluginOptions extends ITsCommonOptions {
 }
 
-export interface ITsPluginTaskOptions {
+export interface ITsPluginTaskOptions extends ITsCommonOptions {
     /**
-     * Log additional debug messages as verbose grunt messages
-     */
-     debug?: boolean;
-
-     /**
      * The path to the tsConfig file to use
      */
     tsconfig?: string;
 
     /**
-     * Pass in additional flags to the tsc compiler (added to the end of the command line)
+     * An array of source files to be "added" to the tsconfig as either files or include
      */
-    additionalFlags?: string | string[];
-
-    /**
-     * Should the compile run fail when type errors are identified
-     */
-    failOnTypeErrors?: boolean;
-
-    /**
-     * Identify the root path of the version of the TypeScript is installed, this may include be either
-     * the root folder of where the node_modules/typescript/bin folder is located or the location of
-     * the command-line version of tsc.
-     * Defaults to scanning the file system path to locate the node_modules/typescript/bin folder
-     */
-    tscPath?: string;
- 
-    /**
-     * Identify the complete path to the command line version of tsc
-     * Defaults to "tsc" within the located or defined tscPath
-     */
-    compiler?: string;
-
-    /**
-     * If specified, outDir files are located relative to this location
-     */
-    baseDir?: string;
-
     src?: string[],
+
+    /**
+     * Concatenate the output into a single file using the tsc --out parameter.
+     * If the tscConfig also includes an ```outDir``` this value will be ignored
+     */
     out?: string
 }
 

--- a/ts-plugin/src/ts-plugin.ts
+++ b/ts-plugin/src/ts-plugin.ts
@@ -9,8 +9,18 @@
  */
 
 import { getGruntMultiTaskOptions, resolveValue } from "@nevware21/grunt-plugins-shared-utils";
+import { ErrorHandlerResponse } from "./interfaces/IErrorHandler";
 import { ITsPluginOptions, ITsPluginTaskOptions } from "./interfaces/ITsPluginOptions";
 import { ITypeScriptCompilerOptions, TypeScriptCompiler } from "./TypeScript";
+
+const buildFailingErrors = [
+    "6050",
+    "6051",
+    "6053",
+    "6054",
+    "6059",
+    "6082"
+];
 
 export function pluginFn (grunt: IGrunt) {
     grunt.registerMultiTask("ts", "Compile TypeScript project", function () {
@@ -19,6 +29,7 @@ export function pluginFn (grunt: IGrunt) {
         });
 
         let taskOptions = getGruntMultiTaskOptions<ITsPluginTaskOptions>(grunt, this);
+        let taskFiles = this.files || [];
 
         if (options.debug) {
             grunt.log.verbose.writeln((" Options: [" + JSON.stringify(options) + "]").cyan);
@@ -30,15 +41,36 @@ export function pluginFn (grunt: IGrunt) {
             return false;
         }
 
+        function handleDefaultTsErrors(number: string, line: string) {
+            let response: ErrorHandlerResponse = null;
+
+            if (taskOptions.onError) {
+                response = taskOptions.onError(number, line);
+            }
+
+            if (!response && options.onError) {
+                response = options.onError(number, line);
+            }
+
+            if (!response) {
+                if (buildFailingErrors.indexOf(number) !== -1) {
+                    response = ErrorHandlerResponse.Error;
+                }
+            }
+        
+            return response;
+        }
+        
         let tsOptions:ITypeScriptCompilerOptions = {
             tsconfig: taskOptions.tsconfig,
             tscPath: resolveValue(taskOptions.tscPath, options.tscPath, null),
             compiler: resolveValue(taskOptions.compiler, options.compiler, null),
-            baseDir: resolveValue(taskOptions.baseDir, options.baseDir, null),
             additionalFlags: resolveValue(taskOptions.additionalFlags, taskOptions.additionalFlags, null),
             debug: resolveValue(taskOptions.debug, options.debug, false),
+            logOutput: resolveValue(taskOptions.logOutput, options.logOutput, false),
             failOnTypeErrors: resolveValue(taskOptions.failOnTypeErrors, taskOptions.failOnTypeErrors, false),
-            out: taskOptions.out
+            out: taskOptions.out,
+            onError: resolveValue(taskOptions.onError, options.onError, handleDefaultTsErrors)
         };
 
         //let tsConfig = require(options.tsconfig);
@@ -47,12 +79,23 @@ export function pluginFn (grunt: IGrunt) {
 
         (async function () {
             let ts = new TypeScriptCompiler(grunt, tsOptions);
+            if (files )
 
-            await ts.compile(taskOptions.src || []);
-            done(true);
+            let response = await ts.compile(taskOptions.src || []);
+            if (!response.isSuccess && response.errors) {
+                response.errors.forEach((value) => {
+                    grunt.log.error(value);
+                });
+            }
+
+            if (options.debug) {
+                grunt.log.writeln("Response: " + JSON.stringify(response));
+            }
+
+            done(response.isSuccess ? true : false);
         })().catch((error) => {
-            grunt.log.error(error);
-            done(false);
+            grunt.log.error(JSON.stringify(error));
+            done(error);
         });
     });
 }


### PR DESCRIPTION
  - Support for ```src``` and ```out``` properties on the task to assist with migrating from [grunt-ts](https://www.npmjs.com/package/grunt-ts). Note: Not all of the grunt-ts features are supported and the generation approach is slightly different.
  - Add an ```onError``` task callback to allow project driven pass / fail based on specific TypeScript errors.