### PR TITLE
[BUG] TsConfig file resolution ignores include if there is also a file node present #272

### DIFF
--- a/eslint-ts-plugin/README.md
+++ b/eslint-ts-plugin/README.md
@@ -102,7 +102,10 @@ module.exports = function(grunt) {
     "lint": {
         options: {
             format: "codeframe",
-            suppressWarnings: false
+            suppressWarnings: false,
+            debug: true,
+            logOutput: true,
+            failNoFiles: false          // Defaults to `true` linting will fail if no files are configured
         },
         "shared": {
             tsconfig: "./shared/tsconfig.json",

--- a/eslint-ts-plugin/src/interfaces/IEslintTsPluginOptions.ts
+++ b/eslint-ts-plugin/src/interfaces/IEslintTsPluginOptions.ts
@@ -131,4 +131,9 @@ export interface IEslintTsPluginTaskOptions extends IEsLintOptions {
      * Ignore failures and continue
      */
     ignoreFailures?: boolean;
+
+    /**
+     * Fail the task if no files are found to process (default is true)
+     */
+    failNoFiles?: boolean;
 }

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -91,8 +91,8 @@ module.exports = function (grunt) {
                 ignoreFailures: true
             },
             "shared-test-fix": {
+                tsconfig: "./shared/test/tsconfig.test.json",
                 options: {
-                    tsconfig: "./shared/test/tsconfig.test.json",
                     fix: true
                 }
             },
@@ -105,8 +105,8 @@ module.exports = function (grunt) {
                 ignoreFailures: true
             },
             "shared-fix": {
+                tsconfig: "./shared/tsconfig.json",
                 options: {
-                    tsconfig: "./shared/tsconfig.json",
                     fix: true,
                     src: [
                         "./shared/src/**/*.ts"
@@ -114,14 +114,14 @@ module.exports = function (grunt) {
                 }
             },
             "ts_plugin-fix": {
+                tsconfig: "./ts-plugin/tsconfig.json",
                 options: {
-                    tsconfig: "./ts-plugin/tsconfig.json",
                     fix: true
                 }
             },
             "eslint_ts-fix": {
+                tsconfig: "./eslint-ts-plugin/tsconfig.json",
                 options: {
-                    tsconfig: "./eslint-ts-plugin/tsconfig.json",
                     fix: true,
                 }
             }

--- a/shared/src/fileHelpers.ts
+++ b/shared/src/fileHelpers.ts
@@ -100,7 +100,7 @@ export function findCommonPath(paths: string[], seperator?: string) {
 
 export function normalizePath(thePath: string) {
     if (thePath) {
-        return thePath.replace(/\\/g, "/");
+        return thePath.replace(/\\/g, "/").replace(/\/\.\//g, "/");
     }
 
     return thePath;
@@ -111,7 +111,7 @@ export function makeRelative(thePath: string) {
 }
 
 export function makeRelativeTo(rootPath: string, thePath: string) {
-    return normalizePath(path.relative(rootPath, path.resolve(thePath)));
+    return normalizePath(path.relative(rootPath, path.resolve(normalizePath(thePath))));
 }
 
 function _findPath(rootPath: string, moduleFolder: string, logDebug?: (message: string) => void) {

--- a/shared/test/src/tsConfigDetails.test.ts
+++ b/shared/test/src/tsConfigDetails.test.ts
@@ -353,6 +353,9 @@ describe("getTsConfigDetails", () => {
                 rootDir: "./src",
                 removeComments: true
             },
+            "include" : [
+                "./src/**/*.ts"
+            ],
             "exclude": [
                 "node_modules/"
             ]
@@ -378,6 +381,9 @@ describe("getTsConfigDetails", () => {
                 rootDir: "./src",
                 removeComments: true
             },
+            "include" : [
+                "./src/**/*.ts"
+            ],
             "exclude": [
                 "node_modules/"
             ]
@@ -482,21 +488,21 @@ describe("getTsConfigDetails", () => {
             const details = getTsConfigDetails(grunt, "tsconfig.json", false);
             assert.equal(details.length, 1)
             details[0].addFiles("file1.ts");
-            assert.deepStrictEqual(details[0].tsConfig.include, [ "file1.ts" ]);
+            assert.deepStrictEqual(details[0].tsConfig.include, [ "./src/**/*.ts", "file1.ts" ]);
         });
     
         it("should add multiple files to the tsConfig", () => {
             const details = getTsConfigDetails(grunt, "tsconfig.json", false);
             assert.equal(details.length, 1)
-            details[0].addFiles(["file1.ts", "file2.ts"]);
-            assert.deepStrictEqual(details[0].tsConfig.include, ["file1.ts", "file2.ts"]);
+            details[0].addFiles([ "file1.ts", "file2.ts"]);
+            assert.deepStrictEqual(details[0].tsConfig.include, [ "./src/**/*.ts", "file1.ts", "file2.ts"]);
         });
     
         it("should add the files to the exclude list when they start with \"!\"", () => {
             const details = getTsConfigDetails(grunt, "tsconfig.json", false);
             assert.equal(details.length, 1)
             details[0].addFiles(["!file1.ts", "file2.ts"]);
-            assert.deepStrictEqual(details[0].tsConfig.include, ["file2.ts"]);
+            assert.deepStrictEqual(details[0].tsConfig.include, [ "./src/**/*.ts", "file2.ts" ]);
             assert.deepStrictEqual(details[0].tsConfig.exclude, [ "node_modules/", "file1.ts" ]);
         });
     
@@ -504,7 +510,7 @@ describe("getTsConfigDetails", () => {
             const details = getTsConfigDetails(grunt, "tsconfig.json", false);
             assert.equal(details.length, 1)
             details[0].addFiles(["dir/**", "file2.ts"]);
-            assert.deepStrictEqual(details[0].tsConfig.include, ["dir/**/*", "file2.ts"] );
+            assert.deepStrictEqual(details[0].tsConfig.include, [ "./src/**/*.ts", "dir/**/*", "file2.ts"] );
         });
     });
 
@@ -528,8 +534,9 @@ describe("getTsConfigDetails", () => {
         it("should return an empty array when details.name is null", () => {
             const details = getTsConfigDetails(grunt, null, false);
             assert.equal(details.length, 1)
+            assert.deepStrictEqual(details[0].tsConfig.include, [ "./src/**/*.ts"]);
             const files = details[0].getFiles();
-            assert.deepStrictEqual(files, []);
+            assert.deepStrictEqual(files, [ "./src/**/*.ts" ]);
         });
     });
 

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -18,6 +18,9 @@
       "rootDir": "./src",
       "removeComments": true
     },
+    "include" : [
+        "./src/**/*.ts"
+    ],
     "exclude": [
         "node_modules/"
     ]


### PR DESCRIPTION
[BUG] TsConfig file resolution ignores include if there is also a file node present #272
- Merged files and include
- More debug logging

[BUG] eslint ignoreFailures is not ignoring all failures #271
- Add more logging
- Add `fileNoFiles` (defaults to true)